### PR TITLE
fix: files is not iterable

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,8 +134,8 @@ fs.readFile(projectPath, (err, content) => {
     
     console.log(chalk.white('Start packing ') + chalk.magentaBright(projectPath));
 
-    texturePacker(files, options, (files) => {
-        for(let file of files) {
+    texturePacker(files, options, (outputFiles) => {
+        for(let file of outputFiles) {
             let out = path.resolve(outputPath, file.name);
             console.log(chalk.white('Writing ') + chalk.greenBright(out));
             fs.writeFileSync(out, file.buffer);


### PR DESCRIPTION
```
Start packing /app/example.ftpp
Writing /output/pack-result.plist
/usr/local/lib/node_modules/free-tex-packer-cli/index.js:138
        for(let file of files) {
                        ^

TypeError: files is not iterable
    at /usr/local/lib/node_modules/free-tex-packer-cli/index.js:138:25
    at /usr/local/lib/node_modules/free-tex-packer-cli/node_modules/free-tex-packer-core/index.js:122:27
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.3.0
```