### PR TITLE
Show packer errors from CLI callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,8 +134,13 @@ fs.readFile(projectPath, (err, content) => {
     
     console.log(chalk.white('Start packing ') + chalk.magentaBright(projectPath));
 
-    texturePacker(files, options, (files) => {
-        for(let file of files) {
+    texturePacker(files, options, (result, err) => {
+        if(err) {
+            let msg = err.description || err.message || String(err);
+            console.error(chalk.redBright('Texture pack failed: ') + msg);
+            process.exit(1);
+        }
+        for(let file of result) {
             let out = path.resolve(outputPath, file.name);
             console.log(chalk.white('Writing ') + chalk.greenBright(out));
             fs.writeFileSync(out, file.buffer);


### PR DESCRIPTION
free-tex-packer-core calls the callback as (result, err): on failure the first argument is undefined and the error is the second. The CLI only used the first argument and iterated it, which hid the real error behind "files is not iterable".

I noticed that it didn't tell me that it was failing because I changed the size to an invalid size, but was just spitting a cryptic error message.